### PR TITLE
Change example email to school email

### DIFF
--- a/engineering/1_hello_git.md
+++ b/engineering/1_hello_git.md
@@ -17,7 +17,7 @@ Set your name and email:
 
 ```bash
 git config --global user.name "Your Name"
-git config --global user.email "youremail@example.com"
+git config --global user.email "youremail@charlottesvilleschools.org"
 ```
 
 And just so that we're all on the same page, set Nano to the default editor for git:


### PR DESCRIPTION
I changed the example email for `git config` to be a school email. Should we also mention using a school email when people sign up for GitHub?

closes #3 